### PR TITLE
add '\0' NULL at the end

### DIFF
--- a/word.sh
+++ b/word.sh
@@ -22,4 +22,4 @@ do
 	fi
 done
 
-printf ");"
+printf ",'\\\0');"


### PR DESCRIPTION
Converter function works well that is written in C but it does print some special or ambiguous characters at the end. There after long search and hassle this is the fix that did the trick, which tell converter to stop at Null or not to include unnecessary characters, as we are anyways assuming all strings with 512 size.

ref: https://github.com/mafonya/c_hide_strings/issues/1